### PR TITLE
KAS-1422 rename relation

### DIFF
--- a/repository/index.js
+++ b/repository/index.js
@@ -8,11 +8,12 @@ const getDocumentNamesForAgendaitem = async (uuid) => {
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
   PREFIX pav:  <http://purl.org/pav/>
+  PREFIX besluitvorming:  <http://data.vlaanderen.be/ns/besluitvorming#>
   
   SELECT ?documentContainer ?documentName WHERE {
     GRAPH <${targetGraph}> { 
       ?agendaitem mu:uuid "${uuid}" ;
-        ext:bevatAgendapuntDocumentversie ?documents .
+        besluitvorming:geagendeerdStuk ?documents .
       ?documentContainer dossier:collectie.bestaatUit ?documents .
       ?documents dct:title ?documentName .
       FILTER NOT EXISTS { ?hasNewerVersion pav:previousVersion ?documents . }


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- ext:bevatAgendapuntDocumentversie => besluitvorming:geagendeerdStuk